### PR TITLE
fix: set appropriate defaults for openshift

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -42,12 +42,6 @@ releases:
   version: 0.0.114
   name: jx-preview
   namespace: jx
-- chart: stable/nginx-ingress
-  version: 1.39.1
-  name: nginx-ingress
-  namespace: nginx
-  values:
-  - versionStream/charts/stable/nginx-ingress/values.yaml.gotmpl
 - chart: jenkins-x/lighthouse
   version: 0.0.865
   name: lighthouse

--- a/jx-values.yaml
+++ b/jx-values.yaml
@@ -9,7 +9,7 @@ jxRequirements:
       gitURL: https://github.com/jenkins-x/jx3-pipeline-catalog.git
   cluster:
     chartRepository: http://bucketrepo/bucketrepo/charts
-    clusterName: kind
+    clusterName: todo
     devEnvApprovers:
     - todo
     environmentGitOwner: todo
@@ -17,7 +17,7 @@ jxRequirements:
     gitName: github
     gitServer: https://github.com
     namespace: jx
-    provider: kubernetes
+    provider: openshift
     registry: ghcr.io
   environments:
   - ingress:
@@ -50,6 +50,7 @@ jxRequirements:
   gitops: true
   ingress:
     domain: ""
+    exposer: Route
     externalDNS: false
     namespaceSubDomain: -jx.
     tls:


### PR DESCRIPTION
Just a couple changes that I think are appropriate.

In the case of the `provider: openshift`, I'm just taking what I knew for `jx2`, maybe this is not appropriate here, but I have used this value in my playing around and it seems to work. Also, I learned `exposer: Route` from working with `jx2` and this also seems to work in `jx3`.

The change of `clusterName` from `kind` to `todo`. My thinking on this point is at best uninformed and potentially misguided, but I'm thinking that you want to provide a meaningful name for the cluster. That said, I don't really know how to handle this name. Should it correspond to the name of the gitops repo? For example, if my repo is named `env-<something meaningful to team>` then should my `clusterName` be `<something meaningful to team>`?

